### PR TITLE
chore: set dark layout background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body style={{ minHeight: "100dvh", background: "#ffffffff" }}>
+      <body style={{ minHeight: "100dvh", background: "#0b0b0b" }}>
         <AntdRegistry>
           <ConfigProvider
             theme={{


### PR DESCRIPTION
## Summary
- use dark theme background in root layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in unrelated files)
- `npx eslint src/app/layout.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bd169230c832385bb29aba086ffa1