### PR TITLE
feat: enable dark theme algorithm

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout({
         <AntdRegistry>
           <ConfigProvider
             theme={{
+              algorithm: antdTheme.darkAlgorithm,
               token: {
                 colorBgBase: "#0b0b0b",
                 colorBgContainer: "#141414",


### PR DESCRIPTION
## Summary
- import Ant Design dark theme algorithm
- enable dark algorithm in ConfigProvider while preserving existing tokens

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_689bd16ae64c832384bb0544f159b519