### PR TITLE
feat: add dark theme styling to new combat page

### DIFF
--- a/src/app/combats/new/page.tsx
+++ b/src/app/combats/new/page.tsx
@@ -2,7 +2,8 @@
 
 import AppLayout from '@/components/AppLayout'
 import { Button, Card, Form, Input, Space, Table, Drawer, Select, InputNumber, message } from 'antd'
-import { useState } from 'react'
+import type { ColumnsType } from 'antd/es/table'
+import { useState, CSSProperties } from 'react'
 
 type CreatureDraft = { key: string; name: string; type: 'PC'|'NPC'; ac?: number; hp?: number; notes?: string }
 
@@ -11,14 +12,17 @@ export default function NewCombatPage() {
   const [openDrawer, setOpenDrawer] = useState(false)
   const [rows, setRows] = useState<CreatureDraft[]>([])
 
-  const columns = [
+  const containerStyle: CSSProperties = { backgroundColor: '#1f1f1f', color: '#fff' }
+  const inputStyle: CSSProperties = { backgroundColor: '#141414', color: '#fff' }
+
+  const columns: ColumnsType<CreatureDraft> = [
     { title: 'Nombre', dataIndex: 'name' },
     { title: 'Tipo', dataIndex: 'type' },
     { title: 'AC', dataIndex: 'ac' },
     { title: 'HP', dataIndex: 'hp' },
     {
       title: 'Acciones',
-      render: (_: any, r: CreatureDraft) => (
+      render: (_: unknown, r: CreatureDraft) => (
         <Space>
           <Button type="link" onClick={() => setRows(prev => prev.filter(x => x.key !== r.key))}>Eliminar</Button>
         </Space>
@@ -26,12 +30,15 @@ export default function NewCombatPage() {
     },
   ]
 
-  async function onSubmit(values: any) {
+  type FormValues = { slug: string; name: string; authorEmail?: string }
+
+  async function onSubmit(values: FormValues) {
     const payload = {
       slug: values.slug,
       name: values.name,
       authorEmail: values.authorEmail || 'dm@example.com', // placeholder
-      blueprint: rows.map(({ key, ...rest }) => rest),
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      blueprint: rows.map(({ key: _key, ...rest }) => rest),
     }
     // TODO: POST a /api/combats
     console.log('create combat', payload)
@@ -41,20 +48,20 @@ export default function NewCombatPage() {
 
   return (
     <AppLayout>
-      <Card title="Nuevo combate" bordered style={{ borderRadius: 16 }}>
-        <Form form={form} layout="vertical" onFinish={onSubmit}>
-          <Form.Item label="Nombre" name="name" rules={[{ required: true, message: 'Ingresa un nombre' }]}>
-            <Input placeholder="Emboscada de Goblins" />
+      <Card title="Nuevo combate" bordered style={{ borderRadius: 16, ...containerStyle }}>
+        <Form form={form} layout="vertical" onFinish={onSubmit} style={containerStyle}>
+          <Form.Item label={<span style={{ color: '#fff' }}>Nombre</span>} name="name" rules={[{ required: true, message: 'Ingresa un nombre' }]}>
+            <Input placeholder="Emboscada de Goblins" style={inputStyle} />
           </Form.Item>
-          <Form.Item label="Slug" name="slug" rules={[{ required: true, message: 'Ingresa un slug' }]}>
-            <Input placeholder="emboscada-goblins" />
+          <Form.Item label={<span style={{ color: '#fff' }}>Slug</span>} name="slug" rules={[{ required: true, message: 'Ingresa un slug' }]}>
+            <Input placeholder="emboscada-goblins" style={inputStyle} />
           </Form.Item>
-          <Form.Item label="Autor (email)" name="authorEmail">
-            <Input placeholder="dm@example.com" />
+          <Form.Item label={<span style={{ color: '#fff' }}>Autor (email)</span>} name="authorEmail">
+            <Input placeholder="dm@example.com" style={inputStyle} />
           </Form.Item>
 
-          <Card size="small" title="Criaturas" extra={<Button onClick={() => setOpenDrawer(true)}>Agregar</Button>} style={{ marginBottom: 16 }}>
-            <Table rowKey="key" dataSource={rows} columns={columns as any} pagination={false} />
+          <Card size="small" title={<span style={{ color: '#fff' }}>Criaturas</span>} extra={<Button onClick={() => setOpenDrawer(true)}>Agregar</Button>} style={{ marginBottom: 16, ...containerStyle }}>
+            <Table rowKey="key" dataSource={rows} columns={columns} pagination={false} />
           </Card>
 
           <Space>
@@ -64,18 +71,18 @@ export default function NewCombatPage() {
         </Form>
       </Card>
 
-      <Drawer title="Agregar criatura" open={openDrawer} onClose={() => setOpenDrawer(false)}>
+      <Drawer title="Agregar criatura" open={openDrawer} onClose={() => setOpenDrawer(false)} styles={{ body: containerStyle, header: containerStyle }}>
         <Form layout="vertical" onFinish={(v) => {
           setRows(prev => [...prev, { key: crypto.randomUUID(), ...v }])
           setOpenDrawer(false)
-        }}>
-          <Form.Item label="Nombre" name="name" rules={[{ required: true }]}><Input /></Form.Item>
-          <Form.Item label="Tipo" name="type" rules={[{ required: true }]}>
-            <Select options={[{value:'PC',label:'PJ'}, {value:'NPC',label:'PNJ'}]} />
+        }} style={containerStyle}>
+          <Form.Item label={<span style={{ color: '#fff' }}>Nombre</span>} name="name" rules={[{ required: true }]}><Input style={inputStyle} /></Form.Item>
+          <Form.Item label={<span style={{ color: '#fff' }}>Tipo</span>} name="type" rules={[{ required: true }]}>
+            <Select options={[{value:'PC',label:'PJ'}, {value:'NPC',label:'PNJ'}]} style={inputStyle} dropdownStyle={containerStyle} />
           </Form.Item>
-          <Form.Item label="AC" name="ac"><InputNumber min={0} style={{ width: '100%' }} /></Form.Item>
-          <Form.Item label="HP" name="hp"><InputNumber min={0} style={{ width: '100%' }} /></Form.Item>
-          <Form.Item label="Notas" name="notes"><Input.TextArea rows={3} /></Form.Item>
+          <Form.Item label={<span style={{ color: '#fff' }}>AC</span>} name="ac"><InputNumber min={0} style={{ width: '100%', ...inputStyle }} /></Form.Item>
+          <Form.Item label={<span style={{ color: '#fff' }}>HP</span>} name="hp"><InputNumber min={0} style={{ width: '100%', ...inputStyle }} /></Form.Item>
+          <Form.Item label={<span style={{ color: '#fff' }}>Notas</span>} name="notes"><Input.TextArea rows={3} style={inputStyle} /></Form.Item>
           <Button type="primary" htmlType="submit" block>Agregar</Button>
         </Form>
       </Drawer>


### PR DESCRIPTION
## Summary
- apply dark background and light text to combat creation card and drawer
- ensure form controls use dark styles with high-contrast labels
- add TypeScript typings to avoid any usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx eslint src/app/combats/new/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689bd1738b888323bf4206fcdf9ad71c